### PR TITLE
Handle full SQLite db for sqlite::Ntuple

### DIFF
--- a/cetlib/sqlite/ConnectionFactory.h
+++ b/cetlib/sqlite/ConnectionFactory.h
@@ -32,10 +32,10 @@
 #include "cetlib/sqlite/Connection.h"
 #include "cetlib/sqlite/detail/DefaultDatabaseOpenPolicy.h"
 
-#include <unordered_map>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 #include <utility>
 
 namespace cet::sqlite {
@@ -48,14 +48,16 @@ namespace cet::sqlite {
       -> std::unique_ptr<Connection>;
 
   private:
-    std::unordered_map<std::string, std::weak_ptr<std::recursive_mutex>> databaseLocks_;
+    std::unordered_map<std::string, std::weak_ptr<std::recursive_mutex>>
+      databaseLocks_;
     std::recursive_mutex mutex_;
   };
 
   template <typename DatabaseOpenPolicy, typename... PolicyArgs>
   auto
   ConnectionFactory::make_connection(std::string const& filename,
-                                     PolicyArgs&&... policyArgs) -> std::unique_ptr<Connection>
+                                     PolicyArgs&&... policyArgs)
+    -> std::unique_ptr<Connection>
   {
     // Implementation a la Herb Sutter's favorite 10-liner
     std::lock_guard sentry{mutex_};
@@ -72,7 +74,8 @@ namespace cet::sqlite {
     // constructor for Connection we need to call is private, and make_unique
     //  is not a friend... and the syntax for making the right function template
     //  be a friend is non-obvious.
-    Connection* pc =  new Connection(filename,
+    Connection* pc = new Connection(
+      filename,
       shared_ptr_to_mutex,
       DatabaseOpenPolicy{std::forward<PolicyArgs>(policyArgs)...});
     return std::unique_ptr<Connection>(pc);

--- a/cetlib/sqlite/ConnectionFactory.h
+++ b/cetlib/sqlite/ConnectionFactory.h
@@ -32,7 +32,7 @@
 #include "cetlib/sqlite/Connection.h"
 #include "cetlib/sqlite/detail/DefaultDatabaseOpenPolicy.h"
 
-#include <map>
+#include <unordered_map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -45,17 +45,17 @@ namespace cet::sqlite {
     template <typename DatabaseOpenPolicy = detail::DefaultDatabaseOpenPolicy,
               typename... PolicyArgs>
     auto make_connection(std::string const& file_name, PolicyArgs&&...)
-      -> Connection*;
+      -> std::unique_ptr<Connection>;
 
   private:
-    std::map<std::string, std::weak_ptr<std::recursive_mutex>> databaseLocks_;
+    std::unordered_map<std::string, std::weak_ptr<std::recursive_mutex>> databaseLocks_;
     std::recursive_mutex mutex_;
   };
 
   template <typename DatabaseOpenPolicy, typename... PolicyArgs>
   auto
   ConnectionFactory::make_connection(std::string const& filename,
-                                     PolicyArgs&&... policyArgs) -> Connection*
+                                     PolicyArgs&&... policyArgs) -> std::unique_ptr<Connection>
   {
     // Implementation a la Herb Sutter's favorite 10-liner
     std::lock_guard sentry{mutex_};
@@ -67,11 +67,15 @@ namespace cet::sqlite {
       databaseLocks_[filename] = shared_ptr_to_mutex =
         std::make_shared<std::recursive_mutex>();
     }
-    auto ret = new Connection{
-      filename,
+
+    // We can not just call std::make_unique<Connection>(...) because the
+    // constructor for Connection we need to call is private, and make_unique
+    //  is not a friend... and the syntax for making the right function template
+    //  be a friend is non-obvious.
+    Connection* pc =  new Connection(filename,
       shared_ptr_to_mutex,
-      DatabaseOpenPolicy{std::forward<PolicyArgs>(policyArgs)...}};
-    return ret;
+      DatabaseOpenPolicy{std::forward<PolicyArgs>(policyArgs)...});
+    return std::unique_ptr<Connection>(pc);
   }
 
 } // namespace cet::sqlite

--- a/cetlib/sqlite/Transaction.cc
+++ b/cetlib/sqlite/Transaction.cc
@@ -34,7 +34,8 @@ cet::sqlite::Transaction::~Transaction() noexcept
   // an error message.
   if (db_) {
     sqlite3_exec(db_, "ROLLBACK;", nullptr, nullptr, nullptr);
-    std::cerr << "Transaction d'tor called before commit was called.\n";
+    std::cerr << "Transaction d'tor called before commit was called.\n"
+              << "The associated SQLite database may be full.\n";
   }
 }
 

--- a/cetlib/sqlite/query_result.h
+++ b/cetlib/sqlite/query_result.h
@@ -83,6 +83,13 @@ namespace cet::sqlite {
     {
       return data.end();
     }
+
+    std::size_t
+    size() const
+    {
+      return data.size();
+    }
+
     explicit operator bool() const { return !empty(); }
 
     std::vector<std::string> columns;

--- a/cetlib/test/sqlite/insert_t.cc
+++ b/cetlib/test/sqlite/insert_t.cc
@@ -1,10 +1,10 @@
 // vim: set sw=2 expandtab :
 
+#include "cetlib/sqlite/Connection.h"
+#include "cetlib/sqlite/ConnectionFactory.h"
 #include "cetlib/sqlite/column.h"
 #include "cetlib/sqlite/create_table.h"
 #include "cetlib/sqlite/insert.h"
-#include "cetlib/sqlite/Connection.h"
-#include "cetlib/sqlite/ConnectionFactory.h"
 
 #include <cassert>
 #include <iostream>
@@ -12,30 +12,29 @@
 
 using namespace cet::sqlite;
 
-void test_value_string_construction()
+void
+test_value_string_construction()
 {
-  std::string result = cet::sqlite::detail::values_str(1, "hello, world", 10.25);
+  std::string result =
+    cet::sqlite::detail::values_str(1, "hello, world", 10.25);
   assert(result == "1,\"hello, world\",10.25");
 }
 
-void test_insertion()
+void
+test_insertion()
 {
   const char* fname{"created_by_insert_t.db"};
   remove(fname);
-  
+
   // Create an empty database with a tiny maximum page count.
   ConnectionFactory cf;
   auto pconn = cf.make_connection(fname);
-  assert(pconn);  // the returned pointer is non-null
+  assert(pconn);        // the returned pointer is non-null
   assert(pconn->get()); // the contained sqlite3 db is non-null
   char* errmsg = nullptr;
-  auto rc = sqlite3_exec(*pconn,
-                         "PRAGMA main.max_page_count=2;",
-                         nullptr,
-                         nullptr,
-                         &errmsg);
-  if (rc != SQLITE_OK)
-  {
+  auto rc = sqlite3_exec(
+    *pconn, "PRAGMA main.max_page_count=2;", nullptr, nullptr, &errmsg);
+  if (rc != SQLITE_OK) {
     std::cout << errmsg;
     sqlite3_free(errmsg);
     abort();
@@ -46,7 +45,6 @@ void test_insertion()
   std::string tablename("Workers");
   create_table(*pconn, tablename, column<int>{"x"});
   std::cout << "Table created\n";
-
 
   // The table should be empty.
   query_result<int> res;
@@ -63,7 +61,7 @@ void test_insertion()
   // Insert more values. This should cause our tiny database to be full.
   // This value of max_rows was determined under SQLite version 3.40.1.
   std::size_t const max_rows = 526;
-  for (std::size_t i = 0; i != max_rows-1; ++i) {
+  for (std::size_t i = 0; i != max_rows - 1; ++i) {
     insert_into(*pconn, tablename).values(10);
   }
   res << select("x").from(*pconn, tablename);
@@ -71,25 +69,20 @@ void test_insertion()
   std::cout << max_rows << " values (total) inserted.\n";
 
   // Inserting one more value fails.
-  try
-  {
+  try {
     insert_into(*pconn, tablename).values(20);
     res << select("x").from(*pconn, tablename);
     std::cerr << "Failed to throw required exception\n";
     abort();
   }
-  catch (...)
-  {
-    std::cout <<
-      "Inserting into full DB failed as expected\n";
+  catch (...) {
+    std::cout << "Inserting into full DB failed as expected\n";
   }
   assert(res.size() == max_rows);
   for (auto i = res.begin(); i != res.end(); ++i) {
     assert(std::get<0>(*i) == 10);
   }
-  
 }
-
 
 int
 main()

--- a/cetlib/test/sqlite/insert_t.cc
+++ b/cetlib/test/sqlite/insert_t.cc
@@ -1,11 +1,107 @@
+// vim: set sw=2 expandtab :
+
+#include "cetlib/sqlite/column.h"
+#include "cetlib/sqlite/create_table.h"
 #include "cetlib/sqlite/insert.h"
+#include "cetlib/sqlite/Connection.h"
+#include "cetlib/sqlite/ConnectionFactory.h"
 
 #include <cassert>
+#include <iostream>
 #include <string>
+
+using namespace cet::sqlite;
+
+void test_value_string_construction()
+{
+  std::string result = cet::sqlite::detail::values_str(1, "hello, world", 10.25);
+  assert(result == "1,\"hello, world\",10.25");
+}
+
+void test_insertion()
+{
+  const char* fname{"created_by_insert_t.db"};
+  remove(fname);
+  
+  // Create an empty database with a tiny maximum page count.
+  ConnectionFactory cf;
+  auto pconn = cf.make_connection(fname);
+  assert(pconn);  // the returned pointer is non-null
+  assert(pconn->get()); // the contained sqlite3 db is non-null
+  char* errmsg = nullptr;
+  auto rc = sqlite3_exec(*pconn,
+                         "PRAGMA main.max_page_count=2;",
+                         nullptr,
+                         nullptr,
+                         &errmsg);
+  if (rc != SQLITE_OK)
+  {
+    std::cout << errmsg;
+    sqlite3_free(errmsg);
+    abort();
+  }
+  std::cout << "Connection is created\n";
+
+  // Create an empty table with 1 column of type int.
+  std::string tablename("Workers");
+  create_table(*pconn, tablename, column<int>{"x"});
+  std::cout << "Table created\n";
+
+
+  // The table should be empty.
+  query_result<int> res;
+  res << select("x").from(*pconn, tablename);
+  assert(res.empty());
+  std::cout << "Table is empty\n";
+
+  // Insert a value. The table should then have one value.
+  insert_into(*pconn, tablename).values(10);
+  res << select("x").from(*pconn, tablename);
+  assert(res.size() == 1);
+  std::cout << "First value inserted\n";
+
+  // Insert more values. This should cause our tiny database to be full.
+  // This value of max_rows was determined under SQLite version 3.40.1.
+  std::size_t const max_rows = 526;
+  for (std::size_t i = 0; i != max_rows-1; ++i) {
+    insert_into(*pconn, tablename).values(10);
+  }
+  res << select("x").from(*pconn, tablename);
+  assert(res.size() == max_rows);
+  std::cout << max_rows << " values (total) inserted.\n";
+
+  // Inserting one more value fails.
+  try
+  {
+    insert_into(*pconn, tablename).values(20);
+    res << select("x").from(*pconn, tablename);
+    std::cerr << "Failed to throw required exception\n";
+    abort();
+  }
+  catch (...)
+  {
+    std::cout <<
+      "Inserting into full DB failed as expected\n";
+  }
+  assert(res.size() == max_rows);
+  for (auto i = res.begin(); i != res.end(); ++i) {
+    assert(std::get<0>(*i) == 10);
+  }
+  
+}
+
 
 int
 main()
-{
-  auto const test = cet::sqlite::detail::values_str(1, "hello", 10);
-  assert(test == "1,\"hello\",10");
+try {
+  test_value_string_construction();
+  test_insertion();
+}
+catch (std::exception const& x) {
+  std::cout << x.what() << '\n';
+  return 1;
+}
+catch (...) {
+  std::cout << "Unknown exception caught\n";
+  return 2;
 }


### PR DESCRIPTION
Make it so that filling the database is not an error. Inserts and flushes of Ntuple become no-ops when a db becomes full.