### PR TITLE
md5 usage is deprecated in modern openssl, but WERROR is enabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cet_cmake_env()
 cet_set_compiler_flags(DIAGS VIGILANT
   WERROR
   NO_UNDEFINED
-  EXTRA_FLAGS -pedantic
+  EXTRA_FLAGS -pedantic -Wno-deprecated-declarations
 )
 
 if(DEFINED ENV{CET_SANITIZE_ADDRESS} AND DEFINED ENV{GCC_FQ_DIR})


### PR DESCRIPTION
Add NO_DEPRECATED to cet_set_compiler_flags invocation